### PR TITLE
Added a function that toggles mpd's single mode.

### DIFF
--- a/libmpdee.el
+++ b/libmpdee.el
@@ -1475,6 +1475,17 @@ With ARG, set repeat on iff ARG is positive."
   (mpd-simple-exec conn (concat "repeat " (if arg "1" "0"))))
 
 ;;;###autoload
+(defun mpd-toggle-single (conn &optional arg)
+  "Change single mode of mpd using CONN.
+With ARG, set single on iff ARG is positive."
+  (interactive (list mpd-inter-conn current-prefix-arg))
+  (setq arg (if arg (> (prefix-numeric-value arg) 0)
+	      (string-equal (plist-get (mpd-get-status conn) 'single) "0")))
+  (mpd-simple-exec conn (concat "single " (if arg "1" "0"))))
+
+;;;###
+
+;;;###autoload
 (defun mpd-set-volume (conn vol)
   "Set the volume for the mpd player to volume VOL."
   (interactive


### PR DESCRIPTION
Added a function that toggles mpd's "single" mode. It's slightly modified from preexisting functions. Couldn't copy it more closely as it seems plist-get returns a string when called with 'single. Not sure if this is of any use to anyone other than me, but here it is.

Thank you for your time and your project.
